### PR TITLE
Fix the benchmark script to call `to_a`

### DIFF
--- a/benchmark/select_query.rb
+++ b/benchmark/select_query.rb
@@ -20,7 +20,7 @@ end
 end
 
 Benchmark.ips do |x|
-  x.report("without where") { Post.all.to_sql }
-  x.report('with single condition') { Post.where(title: 'title1').to_sql }
-  x.report('with multiple condition') { Post.where(state: 'draft', comments_count: ..42, likes_count: ..43).to_sql }
+  x.report("without where") { Post.all.to_a }
+  x.report('with single condition') { Post.where(title: 'title1').to_a }
+  x.report('with multiple condition') { Post.where(state: 'draft', comments_count: ..42, likes_count: ..43).to_a }
 end


### PR DESCRIPTION
🙈 

The result is here:

```
# Benchmarking #to_sql mehtod

## Wihtout AR::Originator
ruby benchmark/to_sql.rb
-- create_table(:posts, {:force=>true})
   -> 0.0267s
ruby 3.4.0dev (2024-02-06T03:19:56Z master 4f6b827e98) [arm64-darwin21]
Warming up --------------------------------------
       without where     5.559k i/100ms
with single condition
                         1.897k i/100ms
with multiple condition
                       738.000 i/100ms
Calculating -------------------------------------
       without where     54.668k (± 1.4%) i/s -    277.950k in   5.085263s
with single condition
                         19.110k (± 1.4%) i/s -     96.747k in   5.063646s
with multiple condition
                          7.404k (± 0.6%) i/s -     37.638k in   5.083522s

## With AR::Originator
ruby -r activerecord/originator benchmark/to_sql.rb
-- create_table(:posts, {:force=>true})
   -> 0.0270s
ruby 3.4.0dev (2024-02-06T03:19:56Z master 4f6b827e98) [arm64-darwin21]
Warming up --------------------------------------
       without where     1.197k i/100ms
with single condition
                       592.000 i/100ms
with multiple condition
                       266.000 i/100ms
Calculating -------------------------------------
       without where     11.914k (± 1.3%) i/s -     59.850k in   5.024529s
with single condition
                          6.261k (± 1.6%) i/s -     31.376k in   5.012947s
with multiple condition
                          2.651k (± 2.1%) i/s -     13.300k in   5.018606s
# Benchmarking SELECT Query

## Wihtout AR::Originator
ruby benchmark/select_query.rb
-- create_table(:posts, {:force=>true})
   -> 0.0280s
ruby 3.4.0dev (2024-02-06T03:19:56Z master 4f6b827e98) [arm64-darwin21]
Warming up --------------------------------------
       without where   263.000 i/100ms
with single condition
                       915.000 i/100ms
with multiple condition
                       392.000 i/100ms
Calculating -------------------------------------
       without where      2.626k (± 0.5%) i/s -     13.150k in   5.007232s
with single condition
                          9.192k (± 1.1%) i/s -     46.665k in   5.077269s
with multiple condition
                          3.924k (± 0.6%) i/s -     19.992k in   5.094459s

## With AR::Originator
ruby -r activerecord/originator benchmark/select_query.rb
-- create_table(:posts, {:force=>true})
   -> 0.0337s
ruby 3.4.0dev (2024-02-06T03:19:56Z master 4f6b827e98) [arm64-darwin21]
Warming up --------------------------------------
       without where   212.000 i/100ms
with single condition
                       424.000 i/100ms
with multiple condition
                       209.000 i/100ms
Calculating -------------------------------------
       without where      2.166k (± 0.5%) i/s -     11.024k in   5.089395s
with single condition
                          4.285k (± 0.9%) i/s -     21.624k in   5.046950s
with multiple condition
                          2.044k (± 2.9%) i/s -     10.241k in   5.015491s
```