### PR TITLE
Avoid modifying unnecessary nodes for performance

### DIFF
--- a/lib/activerecord/originator.rb
+++ b/lib/activerecord/originator.rb
@@ -10,7 +10,13 @@ require_relative "originator/arel_node_extension"
 require_relative "originator/arel_visitor_extension"
 require_relative "originator/collector_proxy"
 
-Arel::Nodes::Node.descendants.each do |klass|
+ActiveRecord::Originator::ArelVisitorExtension::TARGET_NODE_CLASSESS.each do |name|
+  begin
+    klass = Arel::Nodes.const_get(name)
+  rescue NameError
+    # Some classes are not defined in old arel
+    next
+  end
   klass.prepend ActiveRecord::Originator::ArelNodeExtension
 end
 Arel::Visitors::ToSql.prepend ActiveRecord::Originator::ArelVisitorExtension

--- a/lib/activerecord/originator/arel_visitor_extension.rb
+++ b/lib/activerecord/originator/arel_visitor_extension.rb
@@ -3,13 +3,7 @@
 module ActiveRecord
   module Originator
     module ArelVisitorExtension
-      def accept(object, collector)
-        super(object, CollectorProxy.new(collector))
-      end
-
-      private
-
-      %i[
+      TARGET_NODE_CLASSESS = %i[
         Ascending
         Descending
         Equality
@@ -21,7 +15,15 @@ module ActiveRecord
         LessThan
         LessThanOrEqual
         GreaterThanOrEqual
-      ].each do |klass_name|
+      ]
+
+      def accept(object, collector)
+        super(object, CollectorProxy.new(collector))
+      end
+
+      private
+
+      TARGET_NODE_CLASSESS.each do |klass_name|
         define_method(:"visit_Arel_Nodes_#{klass_name}") do |o, collector|
           __skip__ = begin
             comment = originator_comment(o)

--- a/sig/activerecord/originator/arel_visitor_extension.rbs
+++ b/sig/activerecord/originator/arel_visitor_extension.rbs
@@ -1,6 +1,7 @@
 module ActiveRecord
   module Originator
     module ArelVisitorExtension : _ArelVisitor
+      TARGET_NODE_CLASSESS: Array[Symbol]
       def accept: (untyped object, _Collector collector) -> untyped
 
       private


### PR DESCRIPTION
# Benchmarking

```
# Benchmarking #to_sql mehtod

## Wihtout AR::Originator
ruby benchmark/to_sql.rb
-- create_table(:posts, {:force=>true})
   -> 0.0306s
ruby 3.4.0dev (2024-02-06T03:19:56Z master 4f6b827e98) [arm64-darwin21]
Warming up --------------------------------------
       without where     5.608k i/100ms
with single condition
                         1.890k i/100ms
with multiple condition
                       740.000 i/100ms
Calculating -------------------------------------
       without where     55.488k (± 0.7%) i/s -    280.400k in   5.053643s
with single condition
                         18.992k (± 2.6%) i/s -     96.390k in   5.078771s
with multiple condition
                          7.378k (± 2.3%) i/s -     37.000k in   5.017968s

## With AR::Originator
ruby -r activerecord/originator benchmark/to_sql.rb
-- create_table(:posts, {:force=>true})
   -> 0.0229s
ruby 3.4.0dev (2024-02-06T03:19:56Z master 4f6b827e98) [arm64-darwin21]
Warming up --------------------------------------
       without where     5.295k i/100ms
with single condition
                         1.469k i/100ms
with multiple condition
                       523.000 i/100ms
Calculating -------------------------------------
       without where     54.545k (± 0.8%) i/s -    275.340k in   5.048271s
with single condition
                         14.777k (± 1.0%) i/s -     74.919k in   5.070334s
with multiple condition
                          5.180k (± 1.4%) i/s -     26.150k in   5.049379s
# Benchmarking SELECT Query

## Wihtout AR::Originator
ruby benchmark/select_query.rb
-- create_table(:posts, {:force=>true})
   -> 0.0277s
ruby 3.4.0dev (2024-02-06T03:19:56Z master 4f6b827e98) [arm64-darwin21]
Warming up --------------------------------------
       without where   263.000 i/100ms
with single condition
                       915.000 i/100ms
with multiple condition
                       393.000 i/100ms
Calculating -------------------------------------
       without where      2.611k (± 1.5%) i/s -     13.150k in   5.036591s
with single condition
                          9.087k (± 1.6%) i/s -     45.750k in   5.035960s
with multiple condition
                          3.898k (± 2.3%) i/s -     19.650k in   5.043484s

## With AR::Originator
ruby -r activerecord/originator benchmark/select_query.rb
-- create_table(:posts, {:force=>true})
   -> 0.0322s
ruby 3.4.0dev (2024-02-06T03:19:56Z master 4f6b827e98) [arm64-darwin21]
Warming up --------------------------------------
       without where   265.000 i/100ms
with single condition
                       787.000 i/100ms
with multiple condition
                       323.000 i/100ms
Calculating -------------------------------------
       without where      2.636k (± 1.1%) i/s -     13.250k in   5.026309s
with single condition
                          7.793k (± 2.6%) i/s -     39.350k in   5.052717s
with multiple condition
                          3.234k (± 1.9%) i/s -     16.473k in   5.095316s
```