### PR TITLE
Add test for `IS NULL` and `IS NOT NULL`

### DIFF
--- a/spec/activerecord/originator_spec.rb
+++ b/spec/activerecord/originator_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe ActiveRecord::Originator do
       end
 
       it 'annotates != operator' do
-        expect(Post.not_eq.to_sql).to eq(<<~SQL)
+        expect(Post.not_eq('hello').to_sql).to eq(<<~SQL)
           SELECT "posts".* FROM "posts" WHERE "posts"."title" != 'hello' /* /spec/support/post.rb:9 */
         SQL
       end
@@ -49,6 +49,18 @@ RSpec.describe ActiveRecord::Originator do
       it 'annotates < operator' do
         expect(Post.compare_id(...42).to_sql).to eq(<<~SQL)
           SELECT "posts".* FROM "posts" WHERE "posts"."id" < 42 /* /spec/support/post.rb:8 */
+        SQL
+      end
+
+      it 'annotates IS NULL operator' do
+        expect(Post.state_for(nil).to_sql).to eq(<<~SQL)
+          SELECT "posts".* FROM "posts" WHERE "posts"."state" IS NULL /* /spec/support/post.rb:6 */
+        SQL
+      end
+
+      it 'annotates IS NOT NULL operator' do
+        expect(Post.not_eq(nil).to_sql).to eq(<<~SQL)
+          SELECT "posts".* FROM "posts" WHERE "posts"."title" IS NOT NULL /* /spec/support/post.rb:9 */
         SQL
       end
     end

--- a/spec/support/post.rb
+++ b/spec/support/post.rb
@@ -6,6 +6,6 @@ class Post < ActiveRecord::Base
   scope :state_for, ->(state) { where(state: state) }
   scope :not_state_for, ->(state) { where.not(state: state) }
   scope :compare_id, ->(range) { where(id: range) }
-  scope :not_eq, -> { where.not(title: 'hello') }
+  scope :not_eq, ->(title) { where.not(title: title) }
   scope :order_by_title, ->(direction) { order(title: direction) }
 end


### PR DESCRIPTION
This PR adds test cases for `IS NULL` and `IS NOT NULL`.

This PR does not change the production code because this gem already supports these syntaxes. Probably Arel treats them as Equality nodes, so it does not need to treat them explicitly.
However these test cases are meaningful because they can detect API changes of Arel in the future. 