### PR TITLE
Remove unnecessary `gems` entry in rbs_collection.yaml

### DIFF
--- a/rbs_collection.lock.yaml
+++ b/rbs_collection.lock.yaml
@@ -6,7 +6,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 372c833bb52be1bc34aef5e2793ab47c35c0dba9
+    revision: be76a75932e8ed6ee91a95ba936cf88b674bf044
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: activerecord
@@ -14,7 +14,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 372c833bb52be1bc34aef5e2793ab47c35c0dba9
+    revision: be76a75932e8ed6ee91a95ba936cf88b674bf044
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: activesupport
@@ -22,7 +22,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 372c833bb52be1bc34aef5e2793ab47c35c0dba9
+    revision: be76a75932e8ed6ee91a95ba936cf88b674bf044
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: base64
@@ -38,7 +38,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 372c833bb52be1bc34aef5e2793ab47c35c0dba9
+    revision: be76a75932e8ed6ee91a95ba936cf88b674bf044
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: connection_pool
@@ -46,7 +46,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 372c833bb52be1bc34aef5e2793ab47c35c0dba9
+    revision: be76a75932e8ed6ee91a95ba936cf88b674bf044
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: date
@@ -62,7 +62,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 372c833bb52be1bc34aef5e2793ab47c35c0dba9
+    revision: be76a75932e8ed6ee91a95ba936cf88b674bf044
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: logger

--- a/rbs_collection.yaml
+++ b/rbs_collection.yaml
@@ -6,8 +6,3 @@ sources:
     repo_dir: gems
 
 path: .gem_rbs_collection
-
-gems:
-  - name: activerecord-originator
-    ignore: true
-  - name: activerecord


### PR DESCRIPTION
Because the latest RBS avoids duplication of the gem defined in the gemspec.