### PR TITLE
Avoid exposing `Rails.backtrace_cleaner` type

### DIFF
--- a/sig/_polyfill/rails.rbs
+++ b/sig/_polyfill/rails.rbs
@@ -1,0 +1,3 @@
+module Rails
+  def self.backtrace_cleaner: () -> untyped
+end

--- a/sig/interfaces.rbs
+++ b/sig/interfaces.rbs
@@ -1,7 +1,3 @@
-module Rails
-  def self.backtrace_cleaner: () -> untyped
-end
-
 module ActiveRecord::Originator
   interface _ArelVisitor
     def accept: (untyped, untyped) -> untyped


### PR DESCRIPTION
Because this type is provided by rails gem