### PR TITLE
Fix error on Rails 7.2

### DIFF
--- a/lib/activerecord/originator/collector_proxy.rb
+++ b/lib/activerecord/originator/collector_proxy.rb
@@ -32,6 +32,14 @@ module ActiveRecord
       def value
         @collector.value
       end
+
+      def retryable
+        @collector.retryable
+      end
+
+      def retryable=(v)
+        @collector.retryable = v
+      end
     end
   end
 end


### PR DESCRIPTION
Fix #21 

This patch fixes the following error

```
Failure/Error: super(object, CollectorProxy.new(collector))

NoMethodError:
  undefined method 'retryable=' for an instance of ActiveRecord::Originator::CollectorProxy
 ./lib/activerecord/originator/arel_visitor_extension.rb:21:in 'ActiveRecord::Originator::ArelVisitorExtension#accept'
 ./spec/support/001_setup_db.rb:2:in '<top (required)>'
 ./spec/spec_helper.rb:24:in 'block in <top (required)>'
 ./spec/spec_helper.rb:24:in '<top (required)>'
```