### PR TITLE
Add format configuration to set log in one line.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,21 @@ $ bundle add activerecord-originator
 You do not need to do anything else. The gem will automatically add comments to the SQL.
 Check the logs to see the comments.
 
+### Configure format
+
+You can set `ActiveRecord::Originator.format` to `:one_liner` if you prefer your SQL log in one line.
+
+```ruby
+# in your configuration file
+ActiveRecord::Originator.format = :one_liner
+```
+
+Then you can get logs like below.
+
+```sql
+Article Load (0.1ms)  SELECT "articles".* FROM "articles" WHERE "articles"."status" = ? /* <- app/models/article.rb:3:in `published' */ AND "articles"."category_id" = ? /* <- app/controllers/articles_controller.rb:3:in `index' */ ORDER BY "articles"."created_at" DESC /* <- app/models/article.rb:4:in `order_by_latest' */
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/activerecord/originator.rb
+++ b/lib/activerecord/originator.rb
@@ -9,6 +9,7 @@ require_relative "originator/version"
 require_relative "originator/arel_node_extension"
 require_relative "originator/arel_visitor_extension"
 require_relative "originator/collector_proxy"
+require_relative "originator/formatter"
 
 ActiveRecord::Originator::ArelVisitorExtension::TARGET_NODE_CLASSESS.each do |name|
   begin
@@ -23,8 +24,12 @@ Arel::Visitors::ToSql.prepend ActiveRecord::Originator::ArelVisitorExtension
 
 module ActiveRecord
   module Originator
+    extend Formatter
+
     mattr_accessor :backtrace_cleaner
   end
 end
+
+ActiveRecord::Originator.format = :default
 
 require_relative "originator/railtie" if defined?(Rails)

--- a/lib/activerecord/originator/arel_visitor_extension.rb
+++ b/lib/activerecord/originator/arel_visitor_extension.rb
@@ -44,7 +44,7 @@ module ActiveRecord
         frame = traces.first
         return unless frame
 
-        " /* #{escape_comment(frame)} */\n"
+        Originator.current_formatter.format(escape_comment(frame))
       end
 
       def escape_comment(comment)

--- a/lib/activerecord/originator/formatter.rb
+++ b/lib/activerecord/originator/formatter.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require_relative "formatter/default"
+require_relative "formatter/one_liner"
+
+module ActiveRecord
+  module Originator
+    module Formatter
+      attr_reader :format, :current_formatter
+
+      def format=(format)
+        @format = format
+        resolve_formatter
+      end
+
+      def resolve_formatter
+        case format
+        when :one_liner
+          @current_formatter = OneLiner
+        else
+          @current_formatter = Default
+        end
+      end
+    end
+  end
+end

--- a/lib/activerecord/originator/formatter/default.rb
+++ b/lib/activerecord/originator/formatter/default.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module Originator
+    module Formatter
+      module Default
+        def self.format(comment)
+          " /* #{comment} */\n"
+        end
+      end
+    end
+  end
+end

--- a/lib/activerecord/originator/formatter/one_liner.rb
+++ b/lib/activerecord/originator/formatter/one_liner.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module Originator
+    module Formatter
+      module OneLiner
+        def self.format(comment)
+          " /* <- #{comment} */"
+        end
+      end
+    end
+  end
+end

--- a/sig/activerecord/originator.rbs
+++ b/sig/activerecord/originator.rbs
@@ -1,5 +1,7 @@
 module ActiveRecord
   module Originator
+    extend Formatter
+
     attr_accessor self.backtrace_cleaner: ActiveSupport::BacktraceCleaner?
   end
 end

--- a/sig/activerecord/originator/formatter.rbs
+++ b/sig/activerecord/originator/formatter.rbs
@@ -1,0 +1,12 @@
+module ActiveRecord
+  module Originator
+    module Formatter
+      attr_reader format: Symbol
+      def format=: (Symbol) -> void
+                 
+      attr_reader current_formatter: _Formatter
+
+      def resolve_formatter: () -> _Formatter
+    end
+  end
+end

--- a/sig/activerecord/originator/formatter/default.rbs
+++ b/sig/activerecord/originator/formatter/default.rbs
@@ -1,0 +1,9 @@
+module ActiveRecord
+  module Originator
+    module Formatter
+      module Default
+        extend _Formatter
+      end
+    end
+  end
+end

--- a/sig/activerecord/originator/formatter/one_liner.rbs
+++ b/sig/activerecord/originator/formatter/one_liner.rbs
@@ -1,0 +1,9 @@
+module ActiveRecord
+  module Originator
+    module Formatter
+      module OneLiner
+        extend _Formatter
+      end
+    end
+  end
+end

--- a/sig/interfaces.rbs
+++ b/sig/interfaces.rbs
@@ -9,4 +9,8 @@ module ActiveRecord::Originator
     def add_binds: (untyped, ?untyped) -> self
     def value: () -> untyped
   end
+
+  interface _Formatter
+    def format: (String) -> String
+  end
 end

--- a/spec/activerecord/originator_spec.rb
+++ b/spec/activerecord/originator_spec.rb
@@ -76,5 +76,17 @@ RSpec.describe ActiveRecord::Originator do
         SELECT "posts".* FROM "posts" ORDER BY "posts"."title" DESC /* /spec/support/post.rb:10 */
       SQL
     end
+
+    context 'with one_liner format' do
+      before do
+        ActiveRecord::Originator.format = :one_liner
+      end
+
+      it 'outputs in one line' do
+        expect(Post.hello.draft.to_sql).to eq(<<~SQL.chomp)
+          SELECT "posts".* FROM "posts" WHERE "posts"."title" = 'hello' /* <- /spec/support/post.rb:4 */ AND "posts"."state" = 'draft' /* <- /spec/support/post.rb:5 */
+        SQL
+      end
+    end
   end
 end


### PR DESCRIPTION
Hi.

When I tried this gem in my product, I found colorized formats were broken like below.

```SQL
Book Load (0.6ms)  SELECT `books`.* FROM `books` WHERE `books`.`id` = 1 /* app/models/author.rb:12:in `current_book' */  # <= This line is colorized
LIMIT 1 # <= This line is NOT colorized
```

So, I came up with this idea to set `:one_liner` option.

I would be happy if you check this when you have time.
I hope this makes sense for someone.