### PR TITLE
Fix typo in TARGET_NODE_CLASSESS and remove duplicate GreaterThanOrEqual

### DIFF
--- a/lib/activerecord/originator.rb
+++ b/lib/activerecord/originator.rb
@@ -11,7 +11,7 @@ require_relative "originator/arel_visitor_extension"
 require_relative "originator/collector_proxy"
 require_relative "originator/formatter"
 
-ActiveRecord::Originator::ArelVisitorExtension::TARGET_NODE_CLASSESS.each do |name|
+ActiveRecord::Originator::ArelVisitorExtension::TARGET_NODE_CLASSES.each do |name|
   begin
     klass = Arel::Nodes.const_get(name)
   rescue NameError

--- a/lib/activerecord/originator/arel_visitor_extension.rb
+++ b/lib/activerecord/originator/arel_visitor_extension.rb
@@ -3,7 +3,7 @@
 module ActiveRecord
   module Originator
     module ArelVisitorExtension
-      TARGET_NODE_CLASSESS = %i[
+      TARGET_NODE_CLASSES = %i[
         Ascending
         Descending
         Equality
@@ -14,7 +14,6 @@ module ActiveRecord
         GreaterThan
         LessThan
         LessThanOrEqual
-        GreaterThanOrEqual
       ]
 
       def accept(object, collector)
@@ -23,7 +22,7 @@ module ActiveRecord
 
       private
 
-      TARGET_NODE_CLASSESS.each do |klass_name|
+      TARGET_NODE_CLASSES.each do |klass_name|
         define_method(:"visit_Arel_Nodes_#{klass_name}") do |o, collector|
           __skip__ = begin
             comment = originator_comment(o)


### PR DESCRIPTION
## Summary

- Rename `TARGET_NODE_CLASSESS` to `TARGET_NODE_CLASSES` (extra 'S')
- Remove duplicate `GreaterThanOrEqual` entry from the array